### PR TITLE
Changed HAL*GPIO_EXTI_Callback to HAL_GPIO_EXTI_Callback

### DIFF
--- a/docs/micromouse/stm32cubeide-module.md
+++ b/docs/micromouse/stm32cubeide-module.md
@@ -151,7 +151,7 @@ Do **NOT** delete the comments. When writing code in generated files, you must w
 - Our code will be placed between these two comments. Copy and paste the following between them:
 
 ```c
-void HAL*GPIO_EXTI_Callback(uint16_t GPIO_PIN)
+void HAL_GPIO_EXTI_Callback(uint16_t GPIO_PIN)
 {
   if (GPIO_PIN == Button_Pin)
   {


### PR DESCRIPTION
Changed HAL*GPIO_EXTI_Callback to HAL_GPIO_EXTI_Callback in [Micromouse](https://projects.ieeebruins.com/micromouse/) -> [STM32CubeIDE Module](https://projects.ieeebruins.com/micromouse/stm32cubeide-module) -> [Step 3: Code o’ Clock](https://projects.ieeebruins.com/micromouse/stm32cubeide-module#step-3-code-o-clock)

Corresponds to this [issue](https://github.com/UCLA-IEEE/projects.ieeebruins.com/issues/10#issue-2580468018) 